### PR TITLE
Fix Readme File

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
             <img height=14 src="https://assets.aiwebextensions.com/images/icons/earth/black/icon32.svg">
         </picture>
         &nbsp;English |
-        <a href="zh-cn/#readme">简体中文</a>
+        <a href="docs/zh-cn/#readme">简体中文</a>
     </h6>
 </div>
 


### PR DESCRIPTION
Missing `docs/` results in `404 File not found`
<img width="894" height="356" alt="Image" src="https://github.com/user-attachments/assets/72abe28b-6660-4d66-a061-059aded18562" />

<img width="1740" height="532" alt="Image" src="https://github.com/user-attachments/assets/e8606a3b-ad82-4706-aec0-3e473fdd9b21" />